### PR TITLE
[Docs] Correction for Lakebase with Static Users

### DIFF
--- a/database/demo_setup.py
+++ b/database/demo_setup.py
@@ -2209,10 +2209,7 @@ def setup_analytics():
     conn = get_connection()
     cursor = conn.cursor()
 
-    # Create analytics schema
-    cursor.execute("CREATE SCHEMA IF NOT EXISTS analytics;")
-
-    # Create materialized views
+    # Create materialized views - assuming analytics schema already exists
     cursor.execute(
         """
         CREATE MATERIALIZED VIEW IF NOT EXISTS analytics.inventory_summary AS


### PR DESCRIPTION
## Summary
Updated docs and code to reflect Lakebase PubPr API for new database creation.
e.g. Lakebase currently does not permit static credentials - need to enable this prior to running database setup.